### PR TITLE
Add main app navigation setup

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import QuestionScreen from './QuestionScreen';
+import ResultScreen from './ResultScreen';
+
+const Stack = createStackNavigator();
+
+const App = () => {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Question">
+        <Stack.Screen name="Question" component={QuestionScreen} options={{ title: '肌タイプ診断' }} />
+        <Stack.Screen name="Result" component={ResultScreen} options={{ title: '診断結果' }} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+};
+
+export default App;


### PR DESCRIPTION
## Summary
- Add App component wiring Question and Result screens with stack navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689462224f788322b46699b4b7d97fdd